### PR TITLE
Add run method to OrchestratorAgent and agent-specific implementations

### DIFF
--- a/agents/backend_agent.py
+++ b/agents/backend_agent.py
@@ -2,3 +2,21 @@ from utils.prompts import BACKEND_AGENT_PROMPT
 
 class BackendAgent:
     prompt = BACKEND_AGENT_PROMPT
+
+    def run(self, ticket_data: dict) -> dict:
+        descripcion = ticket_data.get("descripcion", "")
+        # Simulación de código Node.js y explicación
+        codigo = (
+            "```js\n"
+            "// " + descripcion + "\n"
+            "function handler(req, res) {\n"
+            "    res.json({ mensaje: 'Función backend simulada!' });\n"
+            "}\n"
+            "module.exports = handler;\n"
+            "```"
+        )
+        comentario = "Función handler de Node.js simulada que responde con un JSON."
+        return {
+            "codigo": codigo,
+            "comentario": comentario
+        }

--- a/agents/frontend_agent.py
+++ b/agents/frontend_agent.py
@@ -2,3 +2,20 @@ from utils.prompts import FRONTEND_AGENT_PROMPT
 
 class FrontendAgent:
     prompt = FRONTEND_AGENT_PROMPT
+
+    def run(self, ticket_data: dict) -> dict:
+        descripcion = ticket_data.get("descripcion", "")
+        # Simulación de código JSX y comentario
+        codigo = (
+            "```jsx\n"
+            "function DemoComponent() {\n"
+            f"    // {descripcion}\n"
+            "    return <div>Hola, soy un componente simulado!</div>;\n"
+            "}\n"
+            "```"
+        )
+        comentario = "Componente React funcional basado en la descripción del ticket."
+        return {
+            "codigo": codigo,
+            "comentario": comentario
+        }

--- a/agents/orchestrator_agent.py
+++ b/agents/orchestrator_agent.py
@@ -2,3 +2,24 @@ from utils.prompts import ORCHESTRATOR_AGENT_PROMPT
 
 class OrchestratorAgent:
     prompt = ORCHESTRATOR_AGENT_PROMPT
+
+    def run(self, ticket_data: dict) -> dict:
+        tipo = ticket_data.get("tipo")
+        ticket_id = ticket_data.get("id")
+        if tipo == "frontend":
+            from agents.frontend_agent import FrontendAgent
+            resultado = FrontendAgent().run(ticket_data)
+            agente_asignado = "frontend"
+        elif tipo == "backend":
+            from agents.backend_agent import BackendAgent
+            resultado = BackendAgent().run(ticket_data)
+            agente_asignado = "backend"
+        else:
+            # Por ahora no manejar errores ni tareas mixtas
+            resultado = None
+            agente_asignado = None
+        return {
+            "ticket_id": ticket_id,
+            "resultado": resultado,
+            "agente_asignado": agente_asignado,
+        }


### PR DESCRIPTION
This pull request implements the `run` method in the `OrchestratorAgent`, `FrontendAgent`, and `BackendAgent` classes as specified in the task. 

### Changes Made:
1. **OrchestratorAgent**:
   - Added a `run(ticket_data: dict) -> dict` method that identifies the ticket type (either 'frontend' or 'backend') and invokes the appropriate agent's `run` method, passing the ticket data. It returns a dictionary containing the ticket ID, the result from the agent, and the agent assigned.

2. **FrontendAgent**:
   - Implemented a `run(ticket_data: dict) -> dict` method that simulates a frontend component generation based on the ticket description. It returns a JSX snippet and a brief comment.

3. **BackendAgent**:
   - Implemented a `run(ticket_data: dict) -> dict` method that simulates a backend function generation. It returns a Node.js function snippet and a brief comment explaining its purpose.

These changes allow for the structured processing of tickets based on their type, paving the way for more complex handling in future developments.

---

> This pull request was co-created with Cosine Genie

Original Task: [COSINE_AI/wjftuwttt97q](https://cosine.sh/x6g8nytq4wx1/COSINE_AI/task/wjftuwttt97q)
Author: Emiliano Javier Castro
